### PR TITLE
fix: correct spelling of 'NGRome' in about page subtitle

### DIFF
--- a/src/app/pages/about.page.ts
+++ b/src/app/pages/about.page.ts
@@ -18,7 +18,7 @@ export const routeMeta: RouteMeta = {
     <app-page-head
       [title]="'About NGRome Conference & The TEAM'"
       [subtitle]="
-        'NG-Rome is a non-profit community conference run by a team of volunteers. We are all active members of the tech community, and run or contribute to various free local meetups, workshops, and education initiatives.'
+        'NGRome is a non-profit community conference run by a team of volunteers. We are all active members of the tech community, and run or contribute to various free local meetups, workshops, and education initiatives.'
       "
     />
     <app-page-image [image]="'/photo/about-stage.jpg'" />


### PR DESCRIPTION
closes #218 